### PR TITLE
Fix glossary links

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -35,7 +35,7 @@ The overall structure of the metadata file is a list of objects, each of which h
       access:
         # Access control and licensing information
       transport:
-        # |API| information
+        # API information
       representation:
         # Data format information
 
@@ -142,7 +142,7 @@ Transport Block
 
 This section describes the on the wire transport protocol, normally HTTP, but with scope to describe out-of-band
 transports with an initial HTTP negotiation process. It contains at least a single ``http`` key, the value of which
-must be valid `Open|API| <https://swagger.io/specification/>`_
+must be valid `OpenAPI <https://swagger.io/specification/>`_
 
 For example:
 
@@ -150,11 +150,11 @@ For example:
 
    transport:
      http:
-       # This block is mandatory, and contains the Open|API| spec for the secured or open
+       # This block is mandatory, and contains the OpenAPI spec for the secured or open
        # HTTP endpoints (depending on data class)
        openapi: 3.0.0
        info:
-         title: Sample |API|
+         title: Sample API
          description: CSV format data
          version: 0.1.0
        servers:
@@ -258,11 +258,11 @@ in the full metadata file this would be contained within a list. |YAML| form:
          appliesTo: 2022-04-22
      transport:
        http:
-         # This block is mandatory, and contains the Open|API| spec for the secured or open
+         # This block is mandatory, and contains the OpenAPI spec for the secured or open
          # HTTP endpoints (depending on data class)
          openapi: 3.0.0
          info:
-           title: Sample |API|
+           title: Sample API
            description: CSV format data
            version: 0.1.0
          servers:
@@ -309,7 +309,7 @@ Or, in |JSON| form:
           "dct:description": "This is a free text description of the data set",
           "dcat:version": "0.1.2",
           "dcat:versionNotes": "This is a note on this particular version of the dataset",
-          "oe:sensitivityClass": "|OE-SA|",
+          "oe:sensitivityClass": "OE-SA",
           "oe:dataSetStableIdentifier": "myData"
         },
         "access": [
@@ -330,7 +330,7 @@ Or, in |JSON| form:
           "http": {
             "openapi": "3.0.0",
             "info": {
-              "title": "Sample |API|",
+              "title": "Sample API",
               "description": "CSV format data",
               "version": "0.1.0"
             },

--- a/docs/ops_guidelines/data_provider_ops_guidelines.rst
+++ b/docs/ops_guidelines/data_provider_ops_guidelines.rst
@@ -199,7 +199,7 @@ Versioning
 
 All data |APIs| **MUST** include a version number in the path of each data endpoint. This version SHOULD use semantic
 versioning to differentiate between breaking and backwards compatible changes. This **MUST** be documented within the
-Open|API| transport section of the metadata file.
+OpenAPI transport section of the metadata file.
 
 Problem Resolution (Data Providers)
 -----------------------------------


### PR DESCRIPTION
Commit 8e787e98d57da6723 introduced more glossary links, but added them in code samples where they don't work.  It also linked to "API" in the string "OpenAPI" which seems unhelpful.

This commit fixes those things.